### PR TITLE
Update README import instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,18 @@ Do one of the following:
 ```
     var QuickSightEmbedding = require("amazon-quicksight-embedding-sdk");
 ```
+You can also use ES6 import syntax in place of require:
+```
+    import { embedDashboard } from 'amazon-quicksight-embedding-sdk';
+    
+    const dashboard = embedDashboard(options);
+```
+Alternatively, if you need to load the entire module:
+```
+    import * as QuicksightEmbedding from 'amazon-quicksight-embedding-sdk';
 
+    const dashboard = QuickSightEmbedding.embedDashboard(options);
+```
 
 ### Step 2: Configure the dashboard to embed
 Set up the dashboard so you can embed it.


### PR DESCRIPTION
Update README to include instructions on how to import and use SDK with ES6+ syntax.

*Issue #, if available:*
https://github.com/awslabs/amazon-quicksight-embedding-sdk/issues/4

*Description of changes:*
Small change to README

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
