### PR TITLE
Typo in example JS

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Set up the dashboard so you can embed it.
         url: "https://us-east-1.quicksight.aws.amazon.com/sn/dashboards/dashboardId?isauthcode=true&identityprovider=quicksight&code=authcode",
         container: document.getElementById("dashboardContainer"),
         parameters: {
-            country: "United States"
+            country: "United States",
             states: [
                 "California",
                 "Washington"


### PR DESCRIPTION
Example is not valid syntax and resulted in 
> SyntaxError: missing } after property list

due to missing `,` after `country: "United States"`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
