### PR TITLE
Add extra option support for embedding dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ Set up the embedded QuickSight console options.
         locale: "en-US",
         footerPaddingEnabled: true,
         sheetTabsDisabled: false, // use this option to enable or disable sheet tab controls in dashboard embedding
+        undoRedoDisabled: false, // use this option to enable or disable undo and redo option for dashboard embedding
+        resetDisabled: false, // use this option to enable or disable reset option for dashboard embedding
         printEnabled: false, // use this option to enable or disable print option for dashboard embedding
         defaultEmbeddingVisualType: TABLE // this option only applies to experience embedding and will not be used for dashboard embedding
     };
@@ -201,6 +203,12 @@ TABLE
 
 #### FooterPaddingEnabled element (optional)
 The `footerPaddingEnabled` element adds 22 pixels of space at the bottom of the layout. For example, you can set this to `true` if the "Powered by QuickSight" footer blocks part of your visual. The default value is `false`.
+
+### UndoRedoDisabled element (optional)
+The `undoRedoDisabled` element can be used to enable or disable undo and redo option for dashboard embedding. The default value is `false`.
+
+### ResetDisabled element (optional)
+The `resetDisabled` element can be used to enabled or disable reset option for dashboard embedding. The default value is `false`.
 
 #### PrintEnabled element (optional)
 The `printEnabled` element can be used to enable or disable print option for dashboard embedding. The default value is `false`. And, if both undoRedo and reset options are disabled, the navbar and print option wont be shown anyways, even if printEnabled is true.

--- a/src/EmbeddableObject.js
+++ b/src/EmbeddableObject.js
@@ -231,6 +231,8 @@ function getIframeSrc(options): string {
         parameters,
         locale,
         footerPaddingEnabled,
+        undoRedoDisabled,
+        resetDisabled,
         printEnabled,
         sheetTabsDisabled,
     } = options;
@@ -238,6 +240,14 @@ function getIframeSrc(options): string {
 
     if (locale) {
         src = src + '&locale=' + locale;
+    }
+
+    if (undoRedoDisabled) {
+        src = src + '&undoRedoDisabled=' + String(undoRedoDisabled);
+    }
+
+    if (resetDisabled) {
+        src = src + '&resetDisabled=' + String(resetDisabled);
     }
 
     if (printEnabled) {

--- a/src/lib/types.js
+++ b/src/lib/types.js
@@ -10,6 +10,8 @@ export type EmbeddingOptions = {
     parametersChangeCallback: ?Function,
     selectedSheetChangeCallback: ?Function,
     parameters: ?Object,
+    undoRedoDisabled: ?boolean,
+    resetDisabled: ?boolean,
     printEnabled: ?boolean,
     sheetTabsDisabled: ?boolean,
     defaultEmbeddingVisualType: ?string,

--- a/test/EmbeddableObjectTests.js
+++ b/test/EmbeddableObjectTests.js
@@ -28,6 +28,8 @@ const mockOptions = {
     },
     className: 'test-class',
     locale: 'test-locale',
+    undoRedoDisabled: true,
+    resetDisabled: true,
     printEnabled: true,
     footerPaddingEnabled: true,
     sheetTabsDisabled: true,
@@ -82,6 +84,7 @@ describe('EmbeddableObject', function() {
         expect(iFrame.src).to.equal(
             mockUrl +
             '&punyCodeEmbedOrigin=null/-&locale=test-locale' +
+            '&undoRedoDisabled=true&resetDisabled=true' +
             '&printEnabled=true&sheetTabsDisabled=true&footerPaddingEnabled=true' +
             '#p.country=United%20States&p.state=California&p.state=Washington'
         );


### PR DESCRIPTION
target issue #65 

*Description of changes:*

implement support to allow user to set `undoRedoDisabled` and
`resetDisabled` option so that frontend developers can control their
websites UX as much as possible without modifing server side URL
generation logic.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
