### PR TITLE
fix: changed @aws-sdk/client-quicksight dependency type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,12 @@
             "version": "2.6.0",
             "license": "Apache-2.0",
             "dependencies": {
+                "@aws-sdk/client-quicksight": "^3.414.0",
                 "@babel/runtime": "^7.20.6",
                 "punycode": "^2.1.1",
                 "uuid": "^9.0.0"
             },
             "devDependencies": {
-                "@aws-sdk/client-quicksight": "^3.414.0",
                 "@babel/cli": "^7.19.3",
                 "@babel/core": "^7.20.5",
                 "@babel/plugin-transform-runtime": "^7.19.6",
@@ -81,8 +81,8 @@
         },
         "node_modules/@aws-crypto/crc32": {
             "version": "3.0.0",
-            "dev": true,
-            "license": "Apache-2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
+            "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
             "dependencies": {
                 "@aws-crypto/util": "^3.0.0",
                 "@aws-sdk/types": "^3.222.0",
@@ -91,26 +91,26 @@
         },
         "node_modules/@aws-crypto/crc32/node_modules/tslib": {
             "version": "1.14.1",
-            "dev": true,
-            "license": "0BSD"
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/@aws-crypto/ie11-detection": {
             "version": "3.0.0",
-            "dev": true,
-            "license": "Apache-2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
+            "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
             "dependencies": {
                 "tslib": "^1.11.1"
             }
         },
         "node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
             "version": "1.14.1",
-            "dev": true,
-            "license": "0BSD"
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/@aws-crypto/sha256-browser": {
             "version": "3.0.0",
-            "dev": true,
-            "license": "Apache-2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
+            "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
             "dependencies": {
                 "@aws-crypto/ie11-detection": "^3.0.0",
                 "@aws-crypto/sha256-js": "^3.0.0",
@@ -124,13 +124,13 @@
         },
         "node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
             "version": "1.14.1",
-            "dev": true,
-            "license": "0BSD"
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/@aws-crypto/sha256-js": {
             "version": "3.0.0",
-            "dev": true,
-            "license": "Apache-2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
+            "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
             "dependencies": {
                 "@aws-crypto/util": "^3.0.0",
                 "@aws-sdk/types": "^3.222.0",
@@ -139,26 +139,26 @@
         },
         "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
             "version": "1.14.1",
-            "dev": true,
-            "license": "0BSD"
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/@aws-crypto/supports-web-crypto": {
             "version": "3.0.0",
-            "dev": true,
-            "license": "Apache-2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
+            "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
             "dependencies": {
                 "tslib": "^1.11.1"
             }
         },
         "node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
             "version": "1.14.1",
-            "dev": true,
-            "license": "0BSD"
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/@aws-crypto/util": {
             "version": "3.0.0",
-            "dev": true,
-            "license": "Apache-2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+            "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
             "dependencies": {
                 "@aws-sdk/types": "^3.222.0",
                 "@aws-sdk/util-utf8-browser": "^3.0.0",
@@ -167,13 +167,13 @@
         },
         "node_modules/@aws-crypto/util/node_modules/tslib": {
             "version": "1.14.1",
-            "dev": true,
-            "license": "0BSD"
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/@aws-sdk/client-quicksight": {
             "version": "3.414.0",
-            "dev": true,
-            "license": "Apache-2.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-quicksight/-/client-quicksight-3.414.0.tgz",
+            "integrity": "sha512-vGGXiCIDmrfuK/mKqqzzLT3nhOXVrNKO/gq2jiesGTA6MZJ9f1ldiM++nid9+gRI5/fjMjBSrn1D80ECnNNIvA==",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
@@ -219,8 +219,8 @@
         },
         "node_modules/@aws-sdk/client-sso": {
             "version": "3.414.0",
-            "dev": true,
-            "license": "Apache-2.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.414.0.tgz",
+            "integrity": "sha512-GvRwQ7wA3edzsQEKS70ZPhkOUZ62PAiXasjp6GxrsADEb8sV1z4FxXNl9Un/7fQxKkh9QYaK1Wu1PmhLi9MLMg==",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
@@ -263,8 +263,8 @@
         },
         "node_modules/@aws-sdk/client-sts": {
             "version": "3.414.0",
-            "dev": true,
-            "license": "Apache-2.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.414.0.tgz",
+            "integrity": "sha512-xeYH3si6Imp1EWolWn1zuxJJu2AXKwXl1HDftQULwC5AWkm1mNFbXYSJN4hQul1IM+kn+JTRB0XRHByQkKhe+Q==",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
@@ -311,8 +311,8 @@
         },
         "node_modules/@aws-sdk/credential-provider-env": {
             "version": "3.413.0",
-            "dev": true,
-            "license": "Apache-2.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.413.0.tgz",
+            "integrity": "sha512-yeMOkfG20/RlzfPMtQuDB647AcPEvFEVYOWZzAWVJfldYQ5ybKr0d7sBkgG9sdAzGkK3Aw9dE4rigYI8EIqc1Q==",
             "dependencies": {
                 "@aws-sdk/types": "3.413.0",
                 "@smithy/property-provider": "^2.0.0",
@@ -325,8 +325,8 @@
         },
         "node_modules/@aws-sdk/credential-provider-ini": {
             "version": "3.414.0",
-            "dev": true,
-            "license": "Apache-2.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.414.0.tgz",
+            "integrity": "sha512-rlpLLx70roJL/t40opWC96LbIASejdMbRlgSCRpK8b/hKngYDe5A7SRVacaw08vYrAywxRiybxpQOwOt9b++rA==",
             "dependencies": {
                 "@aws-sdk/credential-provider-env": "3.413.0",
                 "@aws-sdk/credential-provider-process": "3.413.0",
@@ -345,8 +345,8 @@
         },
         "node_modules/@aws-sdk/credential-provider-node": {
             "version": "3.414.0",
-            "dev": true,
-            "license": "Apache-2.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.414.0.tgz",
+            "integrity": "sha512-xlkcOUKeGHInxWKKrZKIPSBCUL/ozyCldJBjmMKEj7ZmBAEiDcjpMe3pZ//LibMkCSy0b/7jtyQBE/eaIT2o0A==",
             "dependencies": {
                 "@aws-sdk/credential-provider-env": "3.413.0",
                 "@aws-sdk/credential-provider-ini": "3.414.0",
@@ -366,8 +366,8 @@
         },
         "node_modules/@aws-sdk/credential-provider-process": {
             "version": "3.413.0",
-            "dev": true,
-            "license": "Apache-2.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.413.0.tgz",
+            "integrity": "sha512-GFJdgS14GzJ1wc2DEnS44Z/34iBZ05CAkvDsLN2CMwcDgH4eZuif9/x0lwzIJBK3xVFHzYUeVvEzsqRPbCHRsw==",
             "dependencies": {
                 "@aws-sdk/types": "3.413.0",
                 "@smithy/property-provider": "^2.0.0",
@@ -381,8 +381,8 @@
         },
         "node_modules/@aws-sdk/credential-provider-sso": {
             "version": "3.414.0",
-            "dev": true,
-            "license": "Apache-2.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.414.0.tgz",
+            "integrity": "sha512-w9g2hlkZn7WekWICRqk+L33py7KrjYMFryVpkKXOx2pjDchCfZDr6pL1ml782GZ0L3qsob4SbNpbtp13JprnWQ==",
             "dependencies": {
                 "@aws-sdk/client-sso": "3.414.0",
                 "@aws-sdk/token-providers": "3.413.0",
@@ -398,8 +398,8 @@
         },
         "node_modules/@aws-sdk/credential-provider-web-identity": {
             "version": "3.413.0",
-            "dev": true,
-            "license": "Apache-2.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.413.0.tgz",
+            "integrity": "sha512-5cdA1Iq9JeEHtg59ERV9fdMQ7cS0JF6gH/BWA7HYEUGdSVPXCuwyEggPtG64QgpNU7SmxH+QdDG+Ldxz09ycIA==",
             "dependencies": {
                 "@aws-sdk/types": "3.413.0",
                 "@smithy/property-provider": "^2.0.0",
@@ -412,8 +412,8 @@
         },
         "node_modules/@aws-sdk/middleware-host-header": {
             "version": "3.413.0",
-            "dev": true,
-            "license": "Apache-2.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.413.0.tgz",
+            "integrity": "sha512-r9PQx468EzPHo9wRzZLfgROpKtVdbkteMrdhsuM12bifVHjU1OHr7yfhc1OdWv39X8Xiv6F8n5r+RBQEM0S6+g==",
             "dependencies": {
                 "@aws-sdk/types": "3.413.0",
                 "@smithy/protocol-http": "^3.0.3",
@@ -426,8 +426,8 @@
         },
         "node_modules/@aws-sdk/middleware-logger": {
             "version": "3.413.0",
-            "dev": true,
-            "license": "Apache-2.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.413.0.tgz",
+            "integrity": "sha512-jqcXDubcKvoqBy+kkEa0WoNjG6SveDeyNy+gdGnTV+DEtYjkcHrHJei4q0W5zFl0mzc+dP+z8tJF44rv95ZY3Q==",
             "dependencies": {
                 "@aws-sdk/types": "3.413.0",
                 "@smithy/types": "^2.3.1",
@@ -439,8 +439,8 @@
         },
         "node_modules/@aws-sdk/middleware-recursion-detection": {
             "version": "3.413.0",
-            "dev": true,
-            "license": "Apache-2.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.413.0.tgz",
+            "integrity": "sha512-C6k0IKJk/A4/VBGwUjxEPG+WOjjnmWAZVRBUzaeM7PqRh+g5rLcuIV356ntV3pREVxyiSTePTYVYIHU9YXkLKQ==",
             "dependencies": {
                 "@aws-sdk/types": "3.413.0",
                 "@smithy/protocol-http": "^3.0.3",
@@ -453,8 +453,8 @@
         },
         "node_modules/@aws-sdk/middleware-sdk-sts": {
             "version": "3.413.0",
-            "dev": true,
-            "license": "Apache-2.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.413.0.tgz",
+            "integrity": "sha512-t0u//JUyaEZRVnH5q+Ur3tWnuyIsTdwA0XOdDCZXcSlLYzGp2MI/tScLjn9IydRrceIFpFfmbjk4Nf/Q6TeBTQ==",
             "dependencies": {
                 "@aws-sdk/middleware-signing": "3.413.0",
                 "@aws-sdk/types": "3.413.0",
@@ -467,8 +467,8 @@
         },
         "node_modules/@aws-sdk/middleware-signing": {
             "version": "3.413.0",
-            "dev": true,
-            "license": "Apache-2.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.413.0.tgz",
+            "integrity": "sha512-QFEnVvIKYPCermM+ESxEztgUgXzGSKpnPnohMYNvSZySqmOLu/4VvxiZbRO/BX9J3ZHcUgaw4vKm5VBZRrycxw==",
             "dependencies": {
                 "@aws-sdk/types": "3.413.0",
                 "@smithy/property-provider": "^2.0.0",
@@ -484,8 +484,8 @@
         },
         "node_modules/@aws-sdk/middleware-user-agent": {
             "version": "3.413.0",
-            "dev": true,
-            "license": "Apache-2.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.413.0.tgz",
+            "integrity": "sha512-eVMJyeWxNBqerhfD+sE9sTjDtwQiECrfU6wpUQP5fGPhJD2cVVZPxuTuJGDZCu/4k/V61dF85IYlsPUNLdVQ6w==",
             "dependencies": {
                 "@aws-sdk/types": "3.413.0",
                 "@aws-sdk/util-endpoints": "3.413.0",
@@ -499,8 +499,8 @@
         },
         "node_modules/@aws-sdk/region-config-resolver": {
             "version": "3.413.0",
-            "dev": true,
-            "license": "Apache-2.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.413.0.tgz",
+            "integrity": "sha512-h90e6yyOhvoc+1F5vFk3C5mxwB8RSDEMKTO/fxexyur94seczZ1yxyYkTMZv30oc9RUiToABlHNrh/wxL7TZPQ==",
             "dependencies": {
                 "@smithy/node-config-provider": "^2.0.10",
                 "@smithy/types": "^2.3.1",
@@ -514,8 +514,8 @@
         },
         "node_modules/@aws-sdk/token-providers": {
             "version": "3.413.0",
-            "dev": true,
-            "license": "Apache-2.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.413.0.tgz",
+            "integrity": "sha512-NfP1Ib9LAWVLMTOa/1aJwt4TRrlRrNyukCpVZGfNaMnNNEoP5Rakdbcs8KFVHe/MJzU+GdKVzxQ4TgRkLOGTrA==",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
@@ -559,8 +559,8 @@
         },
         "node_modules/@aws-sdk/types": {
             "version": "3.413.0",
-            "dev": true,
-            "license": "Apache-2.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.413.0.tgz",
+            "integrity": "sha512-j1xib0f/TazIFc5ySIKOlT1ujntRbaoG4LJFeEezz4ji03/wSJMI8Vi4KjzpBp8J1tTu0oRDnsxRIGixsUBeYQ==",
             "dependencies": {
                 "@smithy/types": "^2.3.1",
                 "tslib": "^2.5.0"
@@ -571,8 +571,8 @@
         },
         "node_modules/@aws-sdk/util-endpoints": {
             "version": "3.413.0",
-            "dev": true,
-            "license": "Apache-2.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.413.0.tgz",
+            "integrity": "sha512-VAwr7cITNb1L6/2XUPIbCOuhKGm0VtKCRblurrfUF2bxqG/wtuw/2Fm4ahYJPyxklOSXAMSq+RHdFWcir0YB/g==",
             "dependencies": {
                 "@aws-sdk/types": "3.413.0",
                 "tslib": "^2.5.0"
@@ -582,9 +582,9 @@
             }
         },
         "node_modules/@aws-sdk/util-locate-window": {
-            "version": "3.310.0",
-            "dev": true,
-            "license": "Apache-2.0",
+            "version": "3.495.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.495.0.tgz",
+            "integrity": "sha512-MfaPXT0kLX2tQaR90saBT9fWQq2DHqSSJRzW+MZWsmF+y5LGCOhO22ac/2o6TKSQm7h0HRc2GaADqYYYor62yg==",
             "dependencies": {
                 "tslib": "^2.5.0"
             },
@@ -594,8 +594,8 @@
         },
         "node_modules/@aws-sdk/util-user-agent-browser": {
             "version": "3.413.0",
-            "dev": true,
-            "license": "Apache-2.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.413.0.tgz",
+            "integrity": "sha512-7j/qWcRO2OBZBre2fC6V6M0PAS9n7k6i+VtofPkkhxC2DZszLJElqnooF9hGmVGYK3zR47Np4WjURXKIEZclWg==",
             "dependencies": {
                 "@aws-sdk/types": "3.413.0",
                 "@smithy/types": "^2.3.1",
@@ -605,8 +605,8 @@
         },
         "node_modules/@aws-sdk/util-user-agent-node": {
             "version": "3.413.0",
-            "dev": true,
-            "license": "Apache-2.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.413.0.tgz",
+            "integrity": "sha512-vHm9TVZIzfWMeDvdmoOky6VarqOt8Pr68CESHN0jyuO6XbhCDnr9rpaXiBhbSR+N1Qm7R/AfJgAhQyTMu2G1OA==",
             "dependencies": {
                 "@aws-sdk/types": "3.413.0",
                 "@smithy/node-config-provider": "^2.0.10",
@@ -627,8 +627,8 @@
         },
         "node_modules/@aws-sdk/util-utf8-browser": {
             "version": "3.259.0",
-            "dev": true,
-            "license": "Apache-2.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
+            "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
             "dependencies": {
                 "tslib": "^2.3.1"
             }
@@ -4590,11 +4590,11 @@
             }
         },
         "node_modules/@smithy/abort-controller": {
-            "version": "2.0.8",
-            "dev": true,
-            "license": "Apache-2.0",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.1.1.tgz",
+            "integrity": "sha512-1+qdrUqLhaALYL0iOcN43EP6yAXXQ2wWZ6taf4S2pNGowmOc5gx+iMQv+E42JizNJjB0+gEadOXeV1Bf7JWL1Q==",
             "dependencies": {
-                "@smithy/types": "^2.3.2",
+                "@smithy/types": "^2.9.1",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -4602,14 +4602,14 @@
             }
         },
         "node_modules/@smithy/config-resolver": {
-            "version": "2.0.9",
-            "dev": true,
-            "license": "Apache-2.0",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.1.1.tgz",
+            "integrity": "sha512-lxfLDpZm+AWAHPFZps5JfDoO9Ux1764fOgvRUBpHIO8HWHcSN1dkgsago1qLRVgm1BZ8RCm8cgv99QvtaOWIhw==",
             "dependencies": {
-                "@smithy/node-config-provider": "^2.0.11",
-                "@smithy/types": "^2.3.2",
-                "@smithy/util-config-provider": "^2.0.0",
-                "@smithy/util-middleware": "^2.0.1",
+                "@smithy/node-config-provider": "^2.2.1",
+                "@smithy/types": "^2.9.1",
+                "@smithy/util-config-provider": "^2.2.1",
+                "@smithy/util-middleware": "^2.1.1",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -4617,14 +4617,14 @@
             }
         },
         "node_modules/@smithy/credential-provider-imds": {
-            "version": "2.0.11",
-            "dev": true,
-            "license": "Apache-2.0",
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.2.1.tgz",
+            "integrity": "sha512-7XHjZUxmZYnONheVQL7j5zvZXga+EWNgwEAP6OPZTi7l8J4JTeNh9aIOfE5fKHZ/ee2IeNOh54ZrSna+Vc6TFA==",
             "dependencies": {
-                "@smithy/node-config-provider": "^2.0.11",
-                "@smithy/property-provider": "^2.0.9",
-                "@smithy/types": "^2.3.2",
-                "@smithy/url-parser": "^2.0.8",
+                "@smithy/node-config-provider": "^2.2.1",
+                "@smithy/property-provider": "^2.1.1",
+                "@smithy/types": "^2.9.1",
+                "@smithy/url-parser": "^2.1.1",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -4632,36 +4632,36 @@
             }
         },
         "node_modules/@smithy/eventstream-codec": {
-            "version": "2.0.8",
-            "dev": true,
-            "license": "Apache-2.0",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.1.1.tgz",
+            "integrity": "sha512-E8KYBxBIuU4c+zrpR22VsVrOPoEDzk35bQR3E+xm4k6Pa6JqzkDOdMyf9Atac5GPNKHJBdVaQ4JtjdWX2rl/nw==",
             "dependencies": {
                 "@aws-crypto/crc32": "3.0.0",
-                "@smithy/types": "^2.3.2",
-                "@smithy/util-hex-encoding": "^2.0.0",
+                "@smithy/types": "^2.9.1",
+                "@smithy/util-hex-encoding": "^2.1.1",
                 "tslib": "^2.5.0"
             }
         },
         "node_modules/@smithy/fetch-http-handler": {
-            "version": "2.1.4",
-            "dev": true,
-            "license": "Apache-2.0",
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.4.1.tgz",
+            "integrity": "sha512-VYGLinPsFqH68lxfRhjQaSkjXM7JysUOJDTNjHBuN/ykyRb2f1gyavN9+VhhPTWCy32L4yZ2fdhpCs/nStEicg==",
             "dependencies": {
-                "@smithy/protocol-http": "^3.0.4",
-                "@smithy/querystring-builder": "^2.0.8",
-                "@smithy/types": "^2.3.2",
-                "@smithy/util-base64": "^2.0.0",
+                "@smithy/protocol-http": "^3.1.1",
+                "@smithy/querystring-builder": "^2.1.1",
+                "@smithy/types": "^2.9.1",
+                "@smithy/util-base64": "^2.1.1",
                 "tslib": "^2.5.0"
             }
         },
         "node_modules/@smithy/hash-node": {
-            "version": "2.0.8",
-            "dev": true,
-            "license": "Apache-2.0",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.1.1.tgz",
+            "integrity": "sha512-Qhoq0N8f2OtCnvUpCf+g1vSyhYQrZjhSwvJ9qvR8BUGOtTXiyv2x1OD2e6jVGmlpC4E4ax1USHoyGfV9JFsACg==",
             "dependencies": {
-                "@smithy/types": "^2.3.2",
-                "@smithy/util-buffer-from": "^2.0.0",
-                "@smithy/util-utf8": "^2.0.0",
+                "@smithy/types": "^2.9.1",
+                "@smithy/util-buffer-from": "^2.1.1",
+                "@smithy/util-utf8": "^2.1.1",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -4669,18 +4669,18 @@
             }
         },
         "node_modules/@smithy/invalid-dependency": {
-            "version": "2.0.8",
-            "dev": true,
-            "license": "Apache-2.0",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.1.1.tgz",
+            "integrity": "sha512-7WTgnKw+VPg8fxu2v9AlNOQ5yaz6RA54zOVB4f6vQuR0xFKd+RzlCpt0WidYTsye7F+FYDIaS/RnJW4pxjNInw==",
             "dependencies": {
-                "@smithy/types": "^2.3.2",
+                "@smithy/types": "^2.9.1",
                 "tslib": "^2.5.0"
             }
         },
         "node_modules/@smithy/is-array-buffer": {
-            "version": "2.0.0",
-            "dev": true,
-            "license": "Apache-2.0",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.1.1.tgz",
+            "integrity": "sha512-xozSQrcUinPpNPNPds4S7z/FakDTh1MZWtRP/2vQtYB/u3HYrX2UXuZs+VhaKBd6Vc7g2XPr2ZtwGBNDN6fNKQ==",
             "dependencies": {
                 "tslib": "^2.5.0"
             },
@@ -4689,12 +4689,12 @@
             }
         },
         "node_modules/@smithy/middleware-content-length": {
-            "version": "2.0.10",
-            "dev": true,
-            "license": "Apache-2.0",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.1.1.tgz",
+            "integrity": "sha512-rSr9ezUl9qMgiJR0UVtVOGEZElMdGFyl8FzWEF5iEKTlcWxGr2wTqGfDwtH3LAB7h+FPkxqv4ZU4cpuCN9Kf/g==",
             "dependencies": {
-                "@smithy/protocol-http": "^3.0.4",
-                "@smithy/types": "^2.3.2",
+                "@smithy/protocol-http": "^3.1.1",
+                "@smithy/types": "^2.9.1",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -4702,14 +4702,16 @@
             }
         },
         "node_modules/@smithy/middleware-endpoint": {
-            "version": "2.0.8",
-            "dev": true,
-            "license": "Apache-2.0",
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.4.1.tgz",
+            "integrity": "sha512-XPZTb1E2Oav60Ven3n2PFx+rX9EDsU/jSTA8VDamt7FXks67ekjPY/XrmmPDQaFJOTUHJNKjd8+kZxVO5Ael4Q==",
             "dependencies": {
-                "@smithy/middleware-serde": "^2.0.8",
-                "@smithy/types": "^2.3.2",
-                "@smithy/url-parser": "^2.0.8",
-                "@smithy/util-middleware": "^2.0.1",
+                "@smithy/middleware-serde": "^2.1.1",
+                "@smithy/node-config-provider": "^2.2.1",
+                "@smithy/shared-ini-file-loader": "^2.3.1",
+                "@smithy/types": "^2.9.1",
+                "@smithy/url-parser": "^2.1.1",
+                "@smithy/util-middleware": "^2.1.1",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -4717,16 +4719,17 @@
             }
         },
         "node_modules/@smithy/middleware-retry": {
-            "version": "2.0.11",
-            "dev": true,
-            "license": "Apache-2.0",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.1.1.tgz",
+            "integrity": "sha512-eMIHOBTXro6JZ+WWzZWd/8fS8ht5nS5KDQjzhNMHNRcG5FkNTqcKpYhw7TETMYzbLfhO5FYghHy1vqDWM4FLDA==",
             "dependencies": {
-                "@smithy/node-config-provider": "^2.0.11",
-                "@smithy/protocol-http": "^3.0.4",
-                "@smithy/service-error-classification": "^2.0.1",
-                "@smithy/types": "^2.3.2",
-                "@smithy/util-middleware": "^2.0.1",
-                "@smithy/util-retry": "^2.0.1",
+                "@smithy/node-config-provider": "^2.2.1",
+                "@smithy/protocol-http": "^3.1.1",
+                "@smithy/service-error-classification": "^2.1.1",
+                "@smithy/smithy-client": "^2.3.1",
+                "@smithy/types": "^2.9.1",
+                "@smithy/util-middleware": "^2.1.1",
+                "@smithy/util-retry": "^2.1.1",
                 "tslib": "^2.5.0",
                 "uuid": "^8.3.2"
             },
@@ -4736,18 +4739,18 @@
         },
         "node_modules/@smithy/middleware-retry/node_modules/uuid": {
             "version": "8.3.2",
-            "dev": true,
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
             "bin": {
                 "uuid": "dist/bin/uuid"
             }
         },
         "node_modules/@smithy/middleware-serde": {
-            "version": "2.0.8",
-            "dev": true,
-            "license": "Apache-2.0",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.1.1.tgz",
+            "integrity": "sha512-D8Gq0aQBeE1pxf3cjWVkRr2W54t+cdM2zx78tNrVhqrDykRA7asq8yVJij1u5NDtKzKqzBSPYh7iW0svUKg76g==",
             "dependencies": {
-                "@smithy/types": "^2.3.2",
+                "@smithy/types": "^2.9.1",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -4755,11 +4758,11 @@
             }
         },
         "node_modules/@smithy/middleware-stack": {
-            "version": "2.0.1",
-            "dev": true,
-            "license": "Apache-2.0",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.1.1.tgz",
+            "integrity": "sha512-KPJhRlhsl8CjgGXK/DoDcrFGfAqoqvuwlbxy+uOO4g2Azn1dhH+GVfC3RAp+6PoL5PWPb+vt6Z23FP+Mr6qeCw==",
             "dependencies": {
-                "@smithy/types": "^2.3.2",
+                "@smithy/types": "^2.9.1",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -4767,13 +4770,13 @@
             }
         },
         "node_modules/@smithy/node-config-provider": {
-            "version": "2.0.11",
-            "dev": true,
-            "license": "Apache-2.0",
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.2.1.tgz",
+            "integrity": "sha512-epzK3x1xNxA9oJgHQ5nz+2j6DsJKdHfieb+YgJ7ATWxzNcB7Hc+Uya2TUck5MicOPhDV8HZImND7ZOecVr+OWg==",
             "dependencies": {
-                "@smithy/property-provider": "^2.0.9",
-                "@smithy/shared-ini-file-loader": "^2.0.10",
-                "@smithy/types": "^2.3.2",
+                "@smithy/property-provider": "^2.1.1",
+                "@smithy/shared-ini-file-loader": "^2.3.1",
+                "@smithy/types": "^2.9.1",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -4781,14 +4784,14 @@
             }
         },
         "node_modules/@smithy/node-http-handler": {
-            "version": "2.1.4",
-            "dev": true,
-            "license": "Apache-2.0",
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.3.1.tgz",
+            "integrity": "sha512-gLA8qK2nL9J0Rk/WEZSvgin4AppvuCYRYg61dcUo/uKxvMZsMInL5I5ZdJTogOvdfVug3N2dgI5ffcUfS4S9PA==",
             "dependencies": {
-                "@smithy/abort-controller": "^2.0.8",
-                "@smithy/protocol-http": "^3.0.4",
-                "@smithy/querystring-builder": "^2.0.8",
-                "@smithy/types": "^2.3.2",
+                "@smithy/abort-controller": "^2.1.1",
+                "@smithy/protocol-http": "^3.1.1",
+                "@smithy/querystring-builder": "^2.1.1",
+                "@smithy/types": "^2.9.1",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -4796,11 +4799,11 @@
             }
         },
         "node_modules/@smithy/property-provider": {
-            "version": "2.0.9",
-            "dev": true,
-            "license": "Apache-2.0",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.1.1.tgz",
+            "integrity": "sha512-FX7JhhD/o5HwSwg6GLK9zxrMUrGnb3PzNBrcthqHKBc3dH0UfgEAU24xnJ8F0uow5mj17UeBEOI6o3CF2k7Mhw==",
             "dependencies": {
-                "@smithy/types": "^2.3.2",
+                "@smithy/types": "^2.9.1",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -4808,11 +4811,11 @@
             }
         },
         "node_modules/@smithy/protocol-http": {
-            "version": "3.0.4",
-            "dev": true,
-            "license": "Apache-2.0",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.1.1.tgz",
+            "integrity": "sha512-6ZRTSsaXuSL9++qEwH851hJjUA0OgXdQFCs+VDw4tGH256jQ3TjYY/i34N4vd24RV3nrjNsgd1yhb57uMoKbzQ==",
             "dependencies": {
-                "@smithy/types": "^2.3.2",
+                "@smithy/types": "^2.9.1",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -4820,12 +4823,12 @@
             }
         },
         "node_modules/@smithy/querystring-builder": {
-            "version": "2.0.8",
-            "dev": true,
-            "license": "Apache-2.0",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.1.1.tgz",
+            "integrity": "sha512-C/ko/CeEa8jdYE4gt6nHO5XDrlSJ3vdCG0ZAc6nD5ZIE7LBp0jCx4qoqp7eoutBu7VrGMXERSRoPqwi1WjCPbg==",
             "dependencies": {
-                "@smithy/types": "^2.3.2",
-                "@smithy/util-uri-escape": "^2.0.0",
+                "@smithy/types": "^2.9.1",
+                "@smithy/util-uri-escape": "^2.1.1",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -4833,11 +4836,11 @@
             }
         },
         "node_modules/@smithy/querystring-parser": {
-            "version": "2.0.8",
-            "dev": true,
-            "license": "Apache-2.0",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.1.1.tgz",
+            "integrity": "sha512-H4+6jKGVhG1W4CIxfBaSsbm98lOO88tpDWmZLgkJpt8Zkk/+uG0FmmqMuCAc3HNM2ZDV+JbErxr0l5BcuIf/XQ==",
             "dependencies": {
-                "@smithy/types": "^2.3.2",
+                "@smithy/types": "^2.9.1",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -4845,22 +4848,22 @@
             }
         },
         "node_modules/@smithy/service-error-classification": {
-            "version": "2.0.1",
-            "dev": true,
-            "license": "Apache-2.0",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.1.1.tgz",
+            "integrity": "sha512-txEdZxPUgM1PwGvDvHzqhXisrc5LlRWYCf2yyHfvITWioAKat7srQvpjMAvgzf0t6t7j8yHrryXU9xt7RZqFpw==",
             "dependencies": {
-                "@smithy/types": "^2.3.2"
+                "@smithy/types": "^2.9.1"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
         "node_modules/@smithy/shared-ini-file-loader": {
-            "version": "2.0.10",
-            "dev": true,
-            "license": "Apache-2.0",
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.3.1.tgz",
+            "integrity": "sha512-2E2kh24igmIznHLB6H05Na4OgIEilRu0oQpYXo3LCNRrawHAcfDKq9004zJs+sAMt2X5AbY87CUCJ7IpqpSgdw==",
             "dependencies": {
-                "@smithy/types": "^2.3.2",
+                "@smithy/types": "^2.9.1",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -4868,17 +4871,17 @@
             }
         },
         "node_modules/@smithy/signature-v4": {
-            "version": "2.0.8",
-            "dev": true,
-            "license": "Apache-2.0",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.1.1.tgz",
+            "integrity": "sha512-Hb7xub0NHuvvQD3YwDSdanBmYukoEkhqBjqoxo+bSdC0ryV9cTfgmNjuAQhTPYB6yeU7hTR+sPRiFMlxqv6kmg==",
             "dependencies": {
-                "@smithy/eventstream-codec": "^2.0.8",
-                "@smithy/is-array-buffer": "^2.0.0",
-                "@smithy/types": "^2.3.2",
-                "@smithy/util-hex-encoding": "^2.0.0",
-                "@smithy/util-middleware": "^2.0.1",
-                "@smithy/util-uri-escape": "^2.0.0",
-                "@smithy/util-utf8": "^2.0.0",
+                "@smithy/eventstream-codec": "^2.1.1",
+                "@smithy/is-array-buffer": "^2.1.1",
+                "@smithy/types": "^2.9.1",
+                "@smithy/util-hex-encoding": "^2.1.1",
+                "@smithy/util-middleware": "^2.1.1",
+                "@smithy/util-uri-escape": "^2.1.1",
+                "@smithy/util-utf8": "^2.1.1",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -4886,13 +4889,15 @@
             }
         },
         "node_modules/@smithy/smithy-client": {
-            "version": "2.1.5",
-            "dev": true,
-            "license": "Apache-2.0",
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.3.1.tgz",
+            "integrity": "sha512-YsTdU8xVD64r2pLEwmltrNvZV6XIAC50LN6ivDopdt+YiF/jGH6PY9zUOu0CXD/d8GMB8gbhnpPsdrjAXHS9QA==",
             "dependencies": {
-                "@smithy/middleware-stack": "^2.0.1",
-                "@smithy/types": "^2.3.2",
-                "@smithy/util-stream": "^2.0.11",
+                "@smithy/middleware-endpoint": "^2.4.1",
+                "@smithy/middleware-stack": "^2.1.1",
+                "@smithy/protocol-http": "^3.1.1",
+                "@smithy/types": "^2.9.1",
+                "@smithy/util-stream": "^2.1.1",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -4900,9 +4905,9 @@
             }
         },
         "node_modules/@smithy/types": {
-            "version": "2.3.2",
-            "dev": true,
-            "license": "Apache-2.0",
+            "version": "2.9.1",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.9.1.tgz",
+            "integrity": "sha512-vjXlKNXyprDYDuJ7UW5iobdmyDm6g8dDG+BFUncAg/3XJaN45Gy5RWWWUVgrzIK7S4R1KWgIX5LeJcfvSI24bw==",
             "dependencies": {
                 "tslib": "^2.5.0"
             },
@@ -4911,21 +4916,21 @@
             }
         },
         "node_modules/@smithy/url-parser": {
-            "version": "2.0.8",
-            "dev": true,
-            "license": "Apache-2.0",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.1.1.tgz",
+            "integrity": "sha512-qC9Bv8f/vvFIEkHsiNrUKYNl8uKQnn4BdhXl7VzQRP774AwIjiSMMwkbT+L7Fk8W8rzYVifzJNYxv1HwvfBo3Q==",
             "dependencies": {
-                "@smithy/querystring-parser": "^2.0.8",
-                "@smithy/types": "^2.3.2",
+                "@smithy/querystring-parser": "^2.1.1",
+                "@smithy/types": "^2.9.1",
                 "tslib": "^2.5.0"
             }
         },
         "node_modules/@smithy/util-base64": {
-            "version": "2.0.0",
-            "dev": true,
-            "license": "Apache-2.0",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.1.1.tgz",
+            "integrity": "sha512-UfHVpY7qfF/MrgndI5PexSKVTxSZIdz9InghTFa49QOvuu9I52zLPLUHXvHpNuMb1iD2vmc6R+zbv/bdMipR/g==",
             "dependencies": {
-                "@smithy/util-buffer-from": "^2.0.0",
+                "@smithy/util-buffer-from": "^2.1.1",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -4933,17 +4938,17 @@
             }
         },
         "node_modules/@smithy/util-body-length-browser": {
-            "version": "2.0.0",
-            "dev": true,
-            "license": "Apache-2.0",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.1.1.tgz",
+            "integrity": "sha512-ekOGBLvs1VS2d1zM2ER4JEeBWAvIOUKeaFch29UjjJsxmZ/f0L3K3x0dEETgh3Q9bkZNHgT+rkdl/J/VUqSRag==",
             "dependencies": {
                 "tslib": "^2.5.0"
             }
         },
         "node_modules/@smithy/util-body-length-node": {
-            "version": "2.1.0",
-            "dev": true,
-            "license": "Apache-2.0",
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.2.1.tgz",
+            "integrity": "sha512-/ggJG+ta3IDtpNVq4ktmEUtOkH1LW64RHB5B0hcr5ZaWBmo96UX2cIOVbjCqqDickTXqBWZ4ZO0APuaPrD7Abg==",
             "dependencies": {
                 "tslib": "^2.5.0"
             },
@@ -4952,11 +4957,11 @@
             }
         },
         "node_modules/@smithy/util-buffer-from": {
-            "version": "2.0.0",
-            "dev": true,
-            "license": "Apache-2.0",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.1.1.tgz",
+            "integrity": "sha512-clhNjbyfqIv9Md2Mg6FffGVrJxw7bgK7s3Iax36xnfVj6cg0fUG7I4RH0XgXJF8bxi+saY5HR21g2UPKSxVCXg==",
             "dependencies": {
-                "@smithy/is-array-buffer": "^2.0.0",
+                "@smithy/is-array-buffer": "^2.1.1",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -4964,9 +4969,9 @@
             }
         },
         "node_modules/@smithy/util-config-provider": {
-            "version": "2.0.0",
-            "dev": true,
-            "license": "Apache-2.0",
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.2.1.tgz",
+            "integrity": "sha512-50VL/tx9oYYcjJn/qKqNy7sCtpD0+s8XEBamIFo4mFFTclKMNp+rsnymD796uybjiIquB7VCB/DeafduL0y2kw==",
             "dependencies": {
                 "tslib": "^2.5.0"
             },
@@ -4975,13 +4980,13 @@
             }
         },
         "node_modules/@smithy/util-defaults-mode-browser": {
-            "version": "2.0.9",
-            "dev": true,
-            "license": "Apache-2.0",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.1.1.tgz",
+            "integrity": "sha512-lqLz/9aWRO6mosnXkArtRuQqqZBhNpgI65YDpww4rVQBuUT7qzKbDLG5AmnQTCiU4rOquaZO/Kt0J7q9Uic7MA==",
             "dependencies": {
-                "@smithy/property-provider": "^2.0.9",
-                "@smithy/smithy-client": "^2.1.5",
-                "@smithy/types": "^2.3.2",
+                "@smithy/property-provider": "^2.1.1",
+                "@smithy/smithy-client": "^2.3.1",
+                "@smithy/types": "^2.9.1",
                 "bowser": "^2.11.0",
                 "tslib": "^2.5.0"
             },
@@ -4990,16 +4995,16 @@
             }
         },
         "node_modules/@smithy/util-defaults-mode-node": {
-            "version": "2.0.11",
-            "dev": true,
-            "license": "Apache-2.0",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.2.0.tgz",
+            "integrity": "sha512-iFJp/N4EtkanFpBUtSrrIbtOIBf69KNuve03ic1afhJ9/korDxdM0c6cCH4Ehj/smI9pDCfVv+bqT3xZjF2WaA==",
             "dependencies": {
-                "@smithy/config-resolver": "^2.0.9",
-                "@smithy/credential-provider-imds": "^2.0.11",
-                "@smithy/node-config-provider": "^2.0.11",
-                "@smithy/property-provider": "^2.0.9",
-                "@smithy/smithy-client": "^2.1.5",
-                "@smithy/types": "^2.3.2",
+                "@smithy/config-resolver": "^2.1.1",
+                "@smithy/credential-provider-imds": "^2.2.1",
+                "@smithy/node-config-provider": "^2.2.1",
+                "@smithy/property-provider": "^2.1.1",
+                "@smithy/smithy-client": "^2.3.1",
+                "@smithy/types": "^2.9.1",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -5007,9 +5012,9 @@
             }
         },
         "node_modules/@smithy/util-hex-encoding": {
-            "version": "2.0.0",
-            "dev": true,
-            "license": "Apache-2.0",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.1.1.tgz",
+            "integrity": "sha512-3UNdP2pkYUUBGEXzQI9ODTDK+Tcu1BlCyDBaRHwyxhA+8xLP8agEKQq4MGmpjqb4VQAjq9TwlCQX0kP6XDKYLg==",
             "dependencies": {
                 "tslib": "^2.5.0"
             },
@@ -5018,11 +5023,11 @@
             }
         },
         "node_modules/@smithy/util-middleware": {
-            "version": "2.0.1",
-            "dev": true,
-            "license": "Apache-2.0",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.1.1.tgz",
+            "integrity": "sha512-mKNrk8oz5zqkNcbcgAAepeJbmfUW6ogrT2Z2gDbIUzVzNAHKJQTYmH9jcy0jbWb+m7ubrvXKb6uMjkSgAqqsFA==",
             "dependencies": {
-                "@smithy/types": "^2.3.2",
+                "@smithy/types": "^2.9.1",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -5030,12 +5035,12 @@
             }
         },
         "node_modules/@smithy/util-retry": {
-            "version": "2.0.1",
-            "dev": true,
-            "license": "Apache-2.0",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.1.1.tgz",
+            "integrity": "sha512-Mg+xxWPTeSPrthpC5WAamJ6PW4Kbo01Fm7lWM1jmGRvmrRdsd3192Gz2fBXAMURyXpaNxyZf6Hr/nQ4q70oVEA==",
             "dependencies": {
-                "@smithy/service-error-classification": "^2.0.1",
-                "@smithy/types": "^2.3.2",
+                "@smithy/service-error-classification": "^2.1.1",
+                "@smithy/types": "^2.9.1",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -5043,17 +5048,17 @@
             }
         },
         "node_modules/@smithy/util-stream": {
-            "version": "2.0.11",
-            "dev": true,
-            "license": "Apache-2.0",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.1.1.tgz",
+            "integrity": "sha512-J7SMIpUYvU4DQN55KmBtvaMc7NM3CZ2iWICdcgaovtLzseVhAqFRYqloT3mh0esrFw+3VEK6nQFteFsTqZSECQ==",
             "dependencies": {
-                "@smithy/fetch-http-handler": "^2.1.4",
-                "@smithy/node-http-handler": "^2.1.4",
-                "@smithy/types": "^2.3.2",
-                "@smithy/util-base64": "^2.0.0",
-                "@smithy/util-buffer-from": "^2.0.0",
-                "@smithy/util-hex-encoding": "^2.0.0",
-                "@smithy/util-utf8": "^2.0.0",
+                "@smithy/fetch-http-handler": "^2.4.1",
+                "@smithy/node-http-handler": "^2.3.1",
+                "@smithy/types": "^2.9.1",
+                "@smithy/util-base64": "^2.1.1",
+                "@smithy/util-buffer-from": "^2.1.1",
+                "@smithy/util-hex-encoding": "^2.1.1",
+                "@smithy/util-utf8": "^2.1.1",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -5061,9 +5066,9 @@
             }
         },
         "node_modules/@smithy/util-uri-escape": {
-            "version": "2.0.0",
-            "dev": true,
-            "license": "Apache-2.0",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.1.1.tgz",
+            "integrity": "sha512-saVzI1h6iRBUVSqtnlOnc9ssU09ypo7n+shdQ8hBTZno/9rZ3AuRYvoHInV57VF7Qn7B+pFJG7qTzFiHxWlWBw==",
             "dependencies": {
                 "tslib": "^2.5.0"
             },
@@ -5072,11 +5077,11 @@
             }
         },
         "node_modules/@smithy/util-utf8": {
-            "version": "2.0.0",
-            "dev": true,
-            "license": "Apache-2.0",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.1.1.tgz",
+            "integrity": "sha512-BqTpzYEcUMDwAKr7/mVRUtHDhs6ZoXDi9NypMvMfOr/+u1NW7JgqodPDECiiLboEm6bobcPcECxzjtQh865e9A==",
             "dependencies": {
-                "@smithy/util-buffer-from": "^2.0.0",
+                "@smithy/util-buffer-from": "^2.1.1",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -6159,8 +6164,8 @@
         },
         "node_modules/bowser": {
             "version": "2.11.0",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+            "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
         },
         "node_modules/brace-expansion": {
             "version": "1.1.11",
@@ -7647,7 +7652,8 @@
         },
         "node_modules/fast-xml-parser": {
             "version": "4.2.5",
-            "dev": true,
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
+            "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
             "funding": [
                 {
                     "type": "paypal",
@@ -7658,7 +7664,6 @@
                     "url": "https://github.com/sponsors/NaturalIntelligence"
                 }
             ],
-            "license": "MIT",
             "dependencies": {
                 "strnum": "^1.0.5"
             },
@@ -13261,8 +13266,8 @@
         },
         "node_modules/strnum": {
             "version": "1.0.5",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+            "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
         },
         "node_modules/supports-color": {
             "version": "5.5.0",
@@ -13517,7 +13522,6 @@
         },
         "node_modules/tslib": {
             "version": "2.6.2",
-            "dev": true,
             "license": "0BSD"
         },
         "node_modules/tsutils": {
@@ -14072,7 +14076,8 @@
         },
         "@aws-crypto/crc32": {
             "version": "3.0.0",
-            "dev": true,
+            "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
+            "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
             "requires": {
                 "@aws-crypto/util": "^3.0.0",
                 "@aws-sdk/types": "^3.222.0",
@@ -14081,26 +14086,30 @@
             "dependencies": {
                 "tslib": {
                     "version": "1.14.1",
-                    "dev": true
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
                 }
             }
         },
         "@aws-crypto/ie11-detection": {
             "version": "3.0.0",
-            "dev": true,
+            "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
+            "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
             "requires": {
                 "tslib": "^1.11.1"
             },
             "dependencies": {
                 "tslib": {
                     "version": "1.14.1",
-                    "dev": true
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
                 }
             }
         },
         "@aws-crypto/sha256-browser": {
             "version": "3.0.0",
-            "dev": true,
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
+            "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
             "requires": {
                 "@aws-crypto/ie11-detection": "^3.0.0",
                 "@aws-crypto/sha256-js": "^3.0.0",
@@ -14114,13 +14123,15 @@
             "dependencies": {
                 "tslib": {
                     "version": "1.14.1",
-                    "dev": true
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
                 }
             }
         },
         "@aws-crypto/sha256-js": {
             "version": "3.0.0",
-            "dev": true,
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
+            "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
             "requires": {
                 "@aws-crypto/util": "^3.0.0",
                 "@aws-sdk/types": "^3.222.0",
@@ -14129,26 +14140,30 @@
             "dependencies": {
                 "tslib": {
                     "version": "1.14.1",
-                    "dev": true
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
                 }
             }
         },
         "@aws-crypto/supports-web-crypto": {
             "version": "3.0.0",
-            "dev": true,
+            "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
+            "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
             "requires": {
                 "tslib": "^1.11.1"
             },
             "dependencies": {
                 "tslib": {
                     "version": "1.14.1",
-                    "dev": true
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
                 }
             }
         },
         "@aws-crypto/util": {
             "version": "3.0.0",
-            "dev": true,
+            "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+            "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
             "requires": {
                 "@aws-sdk/types": "^3.222.0",
                 "@aws-sdk/util-utf8-browser": "^3.0.0",
@@ -14157,13 +14172,15 @@
             "dependencies": {
                 "tslib": {
                     "version": "1.14.1",
-                    "dev": true
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
                 }
             }
         },
         "@aws-sdk/client-quicksight": {
             "version": "3.414.0",
-            "dev": true,
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-quicksight/-/client-quicksight-3.414.0.tgz",
+            "integrity": "sha512-vGGXiCIDmrfuK/mKqqzzLT3nhOXVrNKO/gq2jiesGTA6MZJ9f1ldiM++nid9+gRI5/fjMjBSrn1D80ECnNNIvA==",
             "requires": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
@@ -14206,7 +14223,8 @@
         },
         "@aws-sdk/client-sso": {
             "version": "3.414.0",
-            "dev": true,
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.414.0.tgz",
+            "integrity": "sha512-GvRwQ7wA3edzsQEKS70ZPhkOUZ62PAiXasjp6GxrsADEb8sV1z4FxXNl9Un/7fQxKkh9QYaK1Wu1PmhLi9MLMg==",
             "requires": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
@@ -14246,7 +14264,8 @@
         },
         "@aws-sdk/client-sts": {
             "version": "3.414.0",
-            "dev": true,
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.414.0.tgz",
+            "integrity": "sha512-xeYH3si6Imp1EWolWn1zuxJJu2AXKwXl1HDftQULwC5AWkm1mNFbXYSJN4hQul1IM+kn+JTRB0XRHByQkKhe+Q==",
             "requires": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
@@ -14290,7 +14309,8 @@
         },
         "@aws-sdk/credential-provider-env": {
             "version": "3.413.0",
-            "dev": true,
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.413.0.tgz",
+            "integrity": "sha512-yeMOkfG20/RlzfPMtQuDB647AcPEvFEVYOWZzAWVJfldYQ5ybKr0d7sBkgG9sdAzGkK3Aw9dE4rigYI8EIqc1Q==",
             "requires": {
                 "@aws-sdk/types": "3.413.0",
                 "@smithy/property-provider": "^2.0.0",
@@ -14300,7 +14320,8 @@
         },
         "@aws-sdk/credential-provider-ini": {
             "version": "3.414.0",
-            "dev": true,
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.414.0.tgz",
+            "integrity": "sha512-rlpLLx70roJL/t40opWC96LbIASejdMbRlgSCRpK8b/hKngYDe5A7SRVacaw08vYrAywxRiybxpQOwOt9b++rA==",
             "requires": {
                 "@aws-sdk/credential-provider-env": "3.413.0",
                 "@aws-sdk/credential-provider-process": "3.413.0",
@@ -14316,7 +14337,8 @@
         },
         "@aws-sdk/credential-provider-node": {
             "version": "3.414.0",
-            "dev": true,
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.414.0.tgz",
+            "integrity": "sha512-xlkcOUKeGHInxWKKrZKIPSBCUL/ozyCldJBjmMKEj7ZmBAEiDcjpMe3pZ//LibMkCSy0b/7jtyQBE/eaIT2o0A==",
             "requires": {
                 "@aws-sdk/credential-provider-env": "3.413.0",
                 "@aws-sdk/credential-provider-ini": "3.414.0",
@@ -14333,7 +14355,8 @@
         },
         "@aws-sdk/credential-provider-process": {
             "version": "3.413.0",
-            "dev": true,
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.413.0.tgz",
+            "integrity": "sha512-GFJdgS14GzJ1wc2DEnS44Z/34iBZ05CAkvDsLN2CMwcDgH4eZuif9/x0lwzIJBK3xVFHzYUeVvEzsqRPbCHRsw==",
             "requires": {
                 "@aws-sdk/types": "3.413.0",
                 "@smithy/property-provider": "^2.0.0",
@@ -14344,7 +14367,8 @@
         },
         "@aws-sdk/credential-provider-sso": {
             "version": "3.414.0",
-            "dev": true,
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.414.0.tgz",
+            "integrity": "sha512-w9g2hlkZn7WekWICRqk+L33py7KrjYMFryVpkKXOx2pjDchCfZDr6pL1ml782GZ0L3qsob4SbNpbtp13JprnWQ==",
             "requires": {
                 "@aws-sdk/client-sso": "3.414.0",
                 "@aws-sdk/token-providers": "3.413.0",
@@ -14357,7 +14381,8 @@
         },
         "@aws-sdk/credential-provider-web-identity": {
             "version": "3.413.0",
-            "dev": true,
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.413.0.tgz",
+            "integrity": "sha512-5cdA1Iq9JeEHtg59ERV9fdMQ7cS0JF6gH/BWA7HYEUGdSVPXCuwyEggPtG64QgpNU7SmxH+QdDG+Ldxz09ycIA==",
             "requires": {
                 "@aws-sdk/types": "3.413.0",
                 "@smithy/property-provider": "^2.0.0",
@@ -14367,7 +14392,8 @@
         },
         "@aws-sdk/middleware-host-header": {
             "version": "3.413.0",
-            "dev": true,
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.413.0.tgz",
+            "integrity": "sha512-r9PQx468EzPHo9wRzZLfgROpKtVdbkteMrdhsuM12bifVHjU1OHr7yfhc1OdWv39X8Xiv6F8n5r+RBQEM0S6+g==",
             "requires": {
                 "@aws-sdk/types": "3.413.0",
                 "@smithy/protocol-http": "^3.0.3",
@@ -14377,7 +14403,8 @@
         },
         "@aws-sdk/middleware-logger": {
             "version": "3.413.0",
-            "dev": true,
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.413.0.tgz",
+            "integrity": "sha512-jqcXDubcKvoqBy+kkEa0WoNjG6SveDeyNy+gdGnTV+DEtYjkcHrHJei4q0W5zFl0mzc+dP+z8tJF44rv95ZY3Q==",
             "requires": {
                 "@aws-sdk/types": "3.413.0",
                 "@smithy/types": "^2.3.1",
@@ -14386,7 +14413,8 @@
         },
         "@aws-sdk/middleware-recursion-detection": {
             "version": "3.413.0",
-            "dev": true,
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.413.0.tgz",
+            "integrity": "sha512-C6k0IKJk/A4/VBGwUjxEPG+WOjjnmWAZVRBUzaeM7PqRh+g5rLcuIV356ntV3pREVxyiSTePTYVYIHU9YXkLKQ==",
             "requires": {
                 "@aws-sdk/types": "3.413.0",
                 "@smithy/protocol-http": "^3.0.3",
@@ -14396,7 +14424,8 @@
         },
         "@aws-sdk/middleware-sdk-sts": {
             "version": "3.413.0",
-            "dev": true,
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.413.0.tgz",
+            "integrity": "sha512-t0u//JUyaEZRVnH5q+Ur3tWnuyIsTdwA0XOdDCZXcSlLYzGp2MI/tScLjn9IydRrceIFpFfmbjk4Nf/Q6TeBTQ==",
             "requires": {
                 "@aws-sdk/middleware-signing": "3.413.0",
                 "@aws-sdk/types": "3.413.0",
@@ -14406,7 +14435,8 @@
         },
         "@aws-sdk/middleware-signing": {
             "version": "3.413.0",
-            "dev": true,
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.413.0.tgz",
+            "integrity": "sha512-QFEnVvIKYPCermM+ESxEztgUgXzGSKpnPnohMYNvSZySqmOLu/4VvxiZbRO/BX9J3ZHcUgaw4vKm5VBZRrycxw==",
             "requires": {
                 "@aws-sdk/types": "3.413.0",
                 "@smithy/property-provider": "^2.0.0",
@@ -14419,7 +14449,8 @@
         },
         "@aws-sdk/middleware-user-agent": {
             "version": "3.413.0",
-            "dev": true,
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.413.0.tgz",
+            "integrity": "sha512-eVMJyeWxNBqerhfD+sE9sTjDtwQiECrfU6wpUQP5fGPhJD2cVVZPxuTuJGDZCu/4k/V61dF85IYlsPUNLdVQ6w==",
             "requires": {
                 "@aws-sdk/types": "3.413.0",
                 "@aws-sdk/util-endpoints": "3.413.0",
@@ -14430,7 +14461,8 @@
         },
         "@aws-sdk/region-config-resolver": {
             "version": "3.413.0",
-            "dev": true,
+            "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.413.0.tgz",
+            "integrity": "sha512-h90e6yyOhvoc+1F5vFk3C5mxwB8RSDEMKTO/fxexyur94seczZ1yxyYkTMZv30oc9RUiToABlHNrh/wxL7TZPQ==",
             "requires": {
                 "@smithy/node-config-provider": "^2.0.10",
                 "@smithy/types": "^2.3.1",
@@ -14441,7 +14473,8 @@
         },
         "@aws-sdk/token-providers": {
             "version": "3.413.0",
-            "dev": true,
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.413.0.tgz",
+            "integrity": "sha512-NfP1Ib9LAWVLMTOa/1aJwt4TRrlRrNyukCpVZGfNaMnNNEoP5Rakdbcs8KFVHe/MJzU+GdKVzxQ4TgRkLOGTrA==",
             "requires": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
@@ -14482,7 +14515,8 @@
         },
         "@aws-sdk/types": {
             "version": "3.413.0",
-            "dev": true,
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.413.0.tgz",
+            "integrity": "sha512-j1xib0f/TazIFc5ySIKOlT1ujntRbaoG4LJFeEezz4ji03/wSJMI8Vi4KjzpBp8J1tTu0oRDnsxRIGixsUBeYQ==",
             "requires": {
                 "@smithy/types": "^2.3.1",
                 "tslib": "^2.5.0"
@@ -14490,22 +14524,25 @@
         },
         "@aws-sdk/util-endpoints": {
             "version": "3.413.0",
-            "dev": true,
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.413.0.tgz",
+            "integrity": "sha512-VAwr7cITNb1L6/2XUPIbCOuhKGm0VtKCRblurrfUF2bxqG/wtuw/2Fm4ahYJPyxklOSXAMSq+RHdFWcir0YB/g==",
             "requires": {
                 "@aws-sdk/types": "3.413.0",
                 "tslib": "^2.5.0"
             }
         },
         "@aws-sdk/util-locate-window": {
-            "version": "3.310.0",
-            "dev": true,
+            "version": "3.495.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.495.0.tgz",
+            "integrity": "sha512-MfaPXT0kLX2tQaR90saBT9fWQq2DHqSSJRzW+MZWsmF+y5LGCOhO22ac/2o6TKSQm7h0HRc2GaADqYYYor62yg==",
             "requires": {
                 "tslib": "^2.5.0"
             }
         },
         "@aws-sdk/util-user-agent-browser": {
             "version": "3.413.0",
-            "dev": true,
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.413.0.tgz",
+            "integrity": "sha512-7j/qWcRO2OBZBre2fC6V6M0PAS9n7k6i+VtofPkkhxC2DZszLJElqnooF9hGmVGYK3zR47Np4WjURXKIEZclWg==",
             "requires": {
                 "@aws-sdk/types": "3.413.0",
                 "@smithy/types": "^2.3.1",
@@ -14515,7 +14552,8 @@
         },
         "@aws-sdk/util-user-agent-node": {
             "version": "3.413.0",
-            "dev": true,
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.413.0.tgz",
+            "integrity": "sha512-vHm9TVZIzfWMeDvdmoOky6VarqOt8Pr68CESHN0jyuO6XbhCDnr9rpaXiBhbSR+N1Qm7R/AfJgAhQyTMu2G1OA==",
             "requires": {
                 "@aws-sdk/types": "3.413.0",
                 "@smithy/node-config-provider": "^2.0.10",
@@ -14525,7 +14563,8 @@
         },
         "@aws-sdk/util-utf8-browser": {
             "version": "3.259.0",
-            "dev": true,
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
+            "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
             "requires": {
                 "tslib": "^2.3.1"
             }
@@ -17033,357 +17072,401 @@
             }
         },
         "@smithy/abort-controller": {
-            "version": "2.0.8",
-            "dev": true,
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.1.1.tgz",
+            "integrity": "sha512-1+qdrUqLhaALYL0iOcN43EP6yAXXQ2wWZ6taf4S2pNGowmOc5gx+iMQv+E42JizNJjB0+gEadOXeV1Bf7JWL1Q==",
             "requires": {
-                "@smithy/types": "^2.3.2",
+                "@smithy/types": "^2.9.1",
                 "tslib": "^2.5.0"
             }
         },
         "@smithy/config-resolver": {
-            "version": "2.0.9",
-            "dev": true,
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.1.1.tgz",
+            "integrity": "sha512-lxfLDpZm+AWAHPFZps5JfDoO9Ux1764fOgvRUBpHIO8HWHcSN1dkgsago1qLRVgm1BZ8RCm8cgv99QvtaOWIhw==",
             "requires": {
-                "@smithy/node-config-provider": "^2.0.11",
-                "@smithy/types": "^2.3.2",
-                "@smithy/util-config-provider": "^2.0.0",
-                "@smithy/util-middleware": "^2.0.1",
+                "@smithy/node-config-provider": "^2.2.1",
+                "@smithy/types": "^2.9.1",
+                "@smithy/util-config-provider": "^2.2.1",
+                "@smithy/util-middleware": "^2.1.1",
                 "tslib": "^2.5.0"
             }
         },
         "@smithy/credential-provider-imds": {
-            "version": "2.0.11",
-            "dev": true,
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.2.1.tgz",
+            "integrity": "sha512-7XHjZUxmZYnONheVQL7j5zvZXga+EWNgwEAP6OPZTi7l8J4JTeNh9aIOfE5fKHZ/ee2IeNOh54ZrSna+Vc6TFA==",
             "requires": {
-                "@smithy/node-config-provider": "^2.0.11",
-                "@smithy/property-provider": "^2.0.9",
-                "@smithy/types": "^2.3.2",
-                "@smithy/url-parser": "^2.0.8",
+                "@smithy/node-config-provider": "^2.2.1",
+                "@smithy/property-provider": "^2.1.1",
+                "@smithy/types": "^2.9.1",
+                "@smithy/url-parser": "^2.1.1",
                 "tslib": "^2.5.0"
             }
         },
         "@smithy/eventstream-codec": {
-            "version": "2.0.8",
-            "dev": true,
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.1.1.tgz",
+            "integrity": "sha512-E8KYBxBIuU4c+zrpR22VsVrOPoEDzk35bQR3E+xm4k6Pa6JqzkDOdMyf9Atac5GPNKHJBdVaQ4JtjdWX2rl/nw==",
             "requires": {
                 "@aws-crypto/crc32": "3.0.0",
-                "@smithy/types": "^2.3.2",
-                "@smithy/util-hex-encoding": "^2.0.0",
+                "@smithy/types": "^2.9.1",
+                "@smithy/util-hex-encoding": "^2.1.1",
                 "tslib": "^2.5.0"
             }
         },
         "@smithy/fetch-http-handler": {
-            "version": "2.1.4",
-            "dev": true,
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.4.1.tgz",
+            "integrity": "sha512-VYGLinPsFqH68lxfRhjQaSkjXM7JysUOJDTNjHBuN/ykyRb2f1gyavN9+VhhPTWCy32L4yZ2fdhpCs/nStEicg==",
             "requires": {
-                "@smithy/protocol-http": "^3.0.4",
-                "@smithy/querystring-builder": "^2.0.8",
-                "@smithy/types": "^2.3.2",
-                "@smithy/util-base64": "^2.0.0",
+                "@smithy/protocol-http": "^3.1.1",
+                "@smithy/querystring-builder": "^2.1.1",
+                "@smithy/types": "^2.9.1",
+                "@smithy/util-base64": "^2.1.1",
                 "tslib": "^2.5.0"
             }
         },
         "@smithy/hash-node": {
-            "version": "2.0.8",
-            "dev": true,
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.1.1.tgz",
+            "integrity": "sha512-Qhoq0N8f2OtCnvUpCf+g1vSyhYQrZjhSwvJ9qvR8BUGOtTXiyv2x1OD2e6jVGmlpC4E4ax1USHoyGfV9JFsACg==",
             "requires": {
-                "@smithy/types": "^2.3.2",
-                "@smithy/util-buffer-from": "^2.0.0",
-                "@smithy/util-utf8": "^2.0.0",
+                "@smithy/types": "^2.9.1",
+                "@smithy/util-buffer-from": "^2.1.1",
+                "@smithy/util-utf8": "^2.1.1",
                 "tslib": "^2.5.0"
             }
         },
         "@smithy/invalid-dependency": {
-            "version": "2.0.8",
-            "dev": true,
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.1.1.tgz",
+            "integrity": "sha512-7WTgnKw+VPg8fxu2v9AlNOQ5yaz6RA54zOVB4f6vQuR0xFKd+RzlCpt0WidYTsye7F+FYDIaS/RnJW4pxjNInw==",
             "requires": {
-                "@smithy/types": "^2.3.2",
+                "@smithy/types": "^2.9.1",
                 "tslib": "^2.5.0"
             }
         },
         "@smithy/is-array-buffer": {
-            "version": "2.0.0",
-            "dev": true,
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.1.1.tgz",
+            "integrity": "sha512-xozSQrcUinPpNPNPds4S7z/FakDTh1MZWtRP/2vQtYB/u3HYrX2UXuZs+VhaKBd6Vc7g2XPr2ZtwGBNDN6fNKQ==",
             "requires": {
                 "tslib": "^2.5.0"
             }
         },
         "@smithy/middleware-content-length": {
-            "version": "2.0.10",
-            "dev": true,
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.1.1.tgz",
+            "integrity": "sha512-rSr9ezUl9qMgiJR0UVtVOGEZElMdGFyl8FzWEF5iEKTlcWxGr2wTqGfDwtH3LAB7h+FPkxqv4ZU4cpuCN9Kf/g==",
             "requires": {
-                "@smithy/protocol-http": "^3.0.4",
-                "@smithy/types": "^2.3.2",
+                "@smithy/protocol-http": "^3.1.1",
+                "@smithy/types": "^2.9.1",
                 "tslib": "^2.5.0"
             }
         },
         "@smithy/middleware-endpoint": {
-            "version": "2.0.8",
-            "dev": true,
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.4.1.tgz",
+            "integrity": "sha512-XPZTb1E2Oav60Ven3n2PFx+rX9EDsU/jSTA8VDamt7FXks67ekjPY/XrmmPDQaFJOTUHJNKjd8+kZxVO5Ael4Q==",
             "requires": {
-                "@smithy/middleware-serde": "^2.0.8",
-                "@smithy/types": "^2.3.2",
-                "@smithy/url-parser": "^2.0.8",
-                "@smithy/util-middleware": "^2.0.1",
+                "@smithy/middleware-serde": "^2.1.1",
+                "@smithy/node-config-provider": "^2.2.1",
+                "@smithy/shared-ini-file-loader": "^2.3.1",
+                "@smithy/types": "^2.9.1",
+                "@smithy/url-parser": "^2.1.1",
+                "@smithy/util-middleware": "^2.1.1",
                 "tslib": "^2.5.0"
             }
         },
         "@smithy/middleware-retry": {
-            "version": "2.0.11",
-            "dev": true,
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.1.1.tgz",
+            "integrity": "sha512-eMIHOBTXro6JZ+WWzZWd/8fS8ht5nS5KDQjzhNMHNRcG5FkNTqcKpYhw7TETMYzbLfhO5FYghHy1vqDWM4FLDA==",
             "requires": {
-                "@smithy/node-config-provider": "^2.0.11",
-                "@smithy/protocol-http": "^3.0.4",
-                "@smithy/service-error-classification": "^2.0.1",
-                "@smithy/types": "^2.3.2",
-                "@smithy/util-middleware": "^2.0.1",
-                "@smithy/util-retry": "^2.0.1",
+                "@smithy/node-config-provider": "^2.2.1",
+                "@smithy/protocol-http": "^3.1.1",
+                "@smithy/service-error-classification": "^2.1.1",
+                "@smithy/smithy-client": "^2.3.1",
+                "@smithy/types": "^2.9.1",
+                "@smithy/util-middleware": "^2.1.1",
+                "@smithy/util-retry": "^2.1.1",
                 "tslib": "^2.5.0",
                 "uuid": "^8.3.2"
             },
             "dependencies": {
                 "uuid": {
                     "version": "8.3.2",
-                    "dev": true
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+                    "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
                 }
             }
         },
         "@smithy/middleware-serde": {
-            "version": "2.0.8",
-            "dev": true,
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.1.1.tgz",
+            "integrity": "sha512-D8Gq0aQBeE1pxf3cjWVkRr2W54t+cdM2zx78tNrVhqrDykRA7asq8yVJij1u5NDtKzKqzBSPYh7iW0svUKg76g==",
             "requires": {
-                "@smithy/types": "^2.3.2",
+                "@smithy/types": "^2.9.1",
                 "tslib": "^2.5.0"
             }
         },
         "@smithy/middleware-stack": {
-            "version": "2.0.1",
-            "dev": true,
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.1.1.tgz",
+            "integrity": "sha512-KPJhRlhsl8CjgGXK/DoDcrFGfAqoqvuwlbxy+uOO4g2Azn1dhH+GVfC3RAp+6PoL5PWPb+vt6Z23FP+Mr6qeCw==",
             "requires": {
-                "@smithy/types": "^2.3.2",
+                "@smithy/types": "^2.9.1",
                 "tslib": "^2.5.0"
             }
         },
         "@smithy/node-config-provider": {
-            "version": "2.0.11",
-            "dev": true,
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.2.1.tgz",
+            "integrity": "sha512-epzK3x1xNxA9oJgHQ5nz+2j6DsJKdHfieb+YgJ7ATWxzNcB7Hc+Uya2TUck5MicOPhDV8HZImND7ZOecVr+OWg==",
             "requires": {
-                "@smithy/property-provider": "^2.0.9",
-                "@smithy/shared-ini-file-loader": "^2.0.10",
-                "@smithy/types": "^2.3.2",
+                "@smithy/property-provider": "^2.1.1",
+                "@smithy/shared-ini-file-loader": "^2.3.1",
+                "@smithy/types": "^2.9.1",
                 "tslib": "^2.5.0"
             }
         },
         "@smithy/node-http-handler": {
-            "version": "2.1.4",
-            "dev": true,
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.3.1.tgz",
+            "integrity": "sha512-gLA8qK2nL9J0Rk/WEZSvgin4AppvuCYRYg61dcUo/uKxvMZsMInL5I5ZdJTogOvdfVug3N2dgI5ffcUfS4S9PA==",
             "requires": {
-                "@smithy/abort-controller": "^2.0.8",
-                "@smithy/protocol-http": "^3.0.4",
-                "@smithy/querystring-builder": "^2.0.8",
-                "@smithy/types": "^2.3.2",
+                "@smithy/abort-controller": "^2.1.1",
+                "@smithy/protocol-http": "^3.1.1",
+                "@smithy/querystring-builder": "^2.1.1",
+                "@smithy/types": "^2.9.1",
                 "tslib": "^2.5.0"
             }
         },
         "@smithy/property-provider": {
-            "version": "2.0.9",
-            "dev": true,
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.1.1.tgz",
+            "integrity": "sha512-FX7JhhD/o5HwSwg6GLK9zxrMUrGnb3PzNBrcthqHKBc3dH0UfgEAU24xnJ8F0uow5mj17UeBEOI6o3CF2k7Mhw==",
             "requires": {
-                "@smithy/types": "^2.3.2",
+                "@smithy/types": "^2.9.1",
                 "tslib": "^2.5.0"
             }
         },
         "@smithy/protocol-http": {
-            "version": "3.0.4",
-            "dev": true,
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.1.1.tgz",
+            "integrity": "sha512-6ZRTSsaXuSL9++qEwH851hJjUA0OgXdQFCs+VDw4tGH256jQ3TjYY/i34N4vd24RV3nrjNsgd1yhb57uMoKbzQ==",
             "requires": {
-                "@smithy/types": "^2.3.2",
+                "@smithy/types": "^2.9.1",
                 "tslib": "^2.5.0"
             }
         },
         "@smithy/querystring-builder": {
-            "version": "2.0.8",
-            "dev": true,
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.1.1.tgz",
+            "integrity": "sha512-C/ko/CeEa8jdYE4gt6nHO5XDrlSJ3vdCG0ZAc6nD5ZIE7LBp0jCx4qoqp7eoutBu7VrGMXERSRoPqwi1WjCPbg==",
             "requires": {
-                "@smithy/types": "^2.3.2",
-                "@smithy/util-uri-escape": "^2.0.0",
+                "@smithy/types": "^2.9.1",
+                "@smithy/util-uri-escape": "^2.1.1",
                 "tslib": "^2.5.0"
             }
         },
         "@smithy/querystring-parser": {
-            "version": "2.0.8",
-            "dev": true,
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.1.1.tgz",
+            "integrity": "sha512-H4+6jKGVhG1W4CIxfBaSsbm98lOO88tpDWmZLgkJpt8Zkk/+uG0FmmqMuCAc3HNM2ZDV+JbErxr0l5BcuIf/XQ==",
             "requires": {
-                "@smithy/types": "^2.3.2",
+                "@smithy/types": "^2.9.1",
                 "tslib": "^2.5.0"
             }
         },
         "@smithy/service-error-classification": {
-            "version": "2.0.1",
-            "dev": true,
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.1.1.tgz",
+            "integrity": "sha512-txEdZxPUgM1PwGvDvHzqhXisrc5LlRWYCf2yyHfvITWioAKat7srQvpjMAvgzf0t6t7j8yHrryXU9xt7RZqFpw==",
             "requires": {
-                "@smithy/types": "^2.3.2"
+                "@smithy/types": "^2.9.1"
             }
         },
         "@smithy/shared-ini-file-loader": {
-            "version": "2.0.10",
-            "dev": true,
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.3.1.tgz",
+            "integrity": "sha512-2E2kh24igmIznHLB6H05Na4OgIEilRu0oQpYXo3LCNRrawHAcfDKq9004zJs+sAMt2X5AbY87CUCJ7IpqpSgdw==",
             "requires": {
-                "@smithy/types": "^2.3.2",
+                "@smithy/types": "^2.9.1",
                 "tslib": "^2.5.0"
             }
         },
         "@smithy/signature-v4": {
-            "version": "2.0.8",
-            "dev": true,
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.1.1.tgz",
+            "integrity": "sha512-Hb7xub0NHuvvQD3YwDSdanBmYukoEkhqBjqoxo+bSdC0ryV9cTfgmNjuAQhTPYB6yeU7hTR+sPRiFMlxqv6kmg==",
             "requires": {
-                "@smithy/eventstream-codec": "^2.0.8",
-                "@smithy/is-array-buffer": "^2.0.0",
-                "@smithy/types": "^2.3.2",
-                "@smithy/util-hex-encoding": "^2.0.0",
-                "@smithy/util-middleware": "^2.0.1",
-                "@smithy/util-uri-escape": "^2.0.0",
-                "@smithy/util-utf8": "^2.0.0",
+                "@smithy/eventstream-codec": "^2.1.1",
+                "@smithy/is-array-buffer": "^2.1.1",
+                "@smithy/types": "^2.9.1",
+                "@smithy/util-hex-encoding": "^2.1.1",
+                "@smithy/util-middleware": "^2.1.1",
+                "@smithy/util-uri-escape": "^2.1.1",
+                "@smithy/util-utf8": "^2.1.1",
                 "tslib": "^2.5.0"
             }
         },
         "@smithy/smithy-client": {
-            "version": "2.1.5",
-            "dev": true,
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.3.1.tgz",
+            "integrity": "sha512-YsTdU8xVD64r2pLEwmltrNvZV6XIAC50LN6ivDopdt+YiF/jGH6PY9zUOu0CXD/d8GMB8gbhnpPsdrjAXHS9QA==",
             "requires": {
-                "@smithy/middleware-stack": "^2.0.1",
-                "@smithy/types": "^2.3.2",
-                "@smithy/util-stream": "^2.0.11",
+                "@smithy/middleware-endpoint": "^2.4.1",
+                "@smithy/middleware-stack": "^2.1.1",
+                "@smithy/protocol-http": "^3.1.1",
+                "@smithy/types": "^2.9.1",
+                "@smithy/util-stream": "^2.1.1",
                 "tslib": "^2.5.0"
             }
         },
         "@smithy/types": {
-            "version": "2.3.2",
-            "dev": true,
+            "version": "2.9.1",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.9.1.tgz",
+            "integrity": "sha512-vjXlKNXyprDYDuJ7UW5iobdmyDm6g8dDG+BFUncAg/3XJaN45Gy5RWWWUVgrzIK7S4R1KWgIX5LeJcfvSI24bw==",
             "requires": {
                 "tslib": "^2.5.0"
             }
         },
         "@smithy/url-parser": {
-            "version": "2.0.8",
-            "dev": true,
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.1.1.tgz",
+            "integrity": "sha512-qC9Bv8f/vvFIEkHsiNrUKYNl8uKQnn4BdhXl7VzQRP774AwIjiSMMwkbT+L7Fk8W8rzYVifzJNYxv1HwvfBo3Q==",
             "requires": {
-                "@smithy/querystring-parser": "^2.0.8",
-                "@smithy/types": "^2.3.2",
+                "@smithy/querystring-parser": "^2.1.1",
+                "@smithy/types": "^2.9.1",
                 "tslib": "^2.5.0"
             }
         },
         "@smithy/util-base64": {
-            "version": "2.0.0",
-            "dev": true,
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.1.1.tgz",
+            "integrity": "sha512-UfHVpY7qfF/MrgndI5PexSKVTxSZIdz9InghTFa49QOvuu9I52zLPLUHXvHpNuMb1iD2vmc6R+zbv/bdMipR/g==",
             "requires": {
-                "@smithy/util-buffer-from": "^2.0.0",
+                "@smithy/util-buffer-from": "^2.1.1",
                 "tslib": "^2.5.0"
             }
         },
         "@smithy/util-body-length-browser": {
-            "version": "2.0.0",
-            "dev": true,
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.1.1.tgz",
+            "integrity": "sha512-ekOGBLvs1VS2d1zM2ER4JEeBWAvIOUKeaFch29UjjJsxmZ/f0L3K3x0dEETgh3Q9bkZNHgT+rkdl/J/VUqSRag==",
             "requires": {
                 "tslib": "^2.5.0"
             }
         },
         "@smithy/util-body-length-node": {
-            "version": "2.1.0",
-            "dev": true,
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.2.1.tgz",
+            "integrity": "sha512-/ggJG+ta3IDtpNVq4ktmEUtOkH1LW64RHB5B0hcr5ZaWBmo96UX2cIOVbjCqqDickTXqBWZ4ZO0APuaPrD7Abg==",
             "requires": {
                 "tslib": "^2.5.0"
             }
         },
         "@smithy/util-buffer-from": {
-            "version": "2.0.0",
-            "dev": true,
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.1.1.tgz",
+            "integrity": "sha512-clhNjbyfqIv9Md2Mg6FffGVrJxw7bgK7s3Iax36xnfVj6cg0fUG7I4RH0XgXJF8bxi+saY5HR21g2UPKSxVCXg==",
             "requires": {
-                "@smithy/is-array-buffer": "^2.0.0",
+                "@smithy/is-array-buffer": "^2.1.1",
                 "tslib": "^2.5.0"
             }
         },
         "@smithy/util-config-provider": {
-            "version": "2.0.0",
-            "dev": true,
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.2.1.tgz",
+            "integrity": "sha512-50VL/tx9oYYcjJn/qKqNy7sCtpD0+s8XEBamIFo4mFFTclKMNp+rsnymD796uybjiIquB7VCB/DeafduL0y2kw==",
             "requires": {
                 "tslib": "^2.5.0"
             }
         },
         "@smithy/util-defaults-mode-browser": {
-            "version": "2.0.9",
-            "dev": true,
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.1.1.tgz",
+            "integrity": "sha512-lqLz/9aWRO6mosnXkArtRuQqqZBhNpgI65YDpww4rVQBuUT7qzKbDLG5AmnQTCiU4rOquaZO/Kt0J7q9Uic7MA==",
             "requires": {
-                "@smithy/property-provider": "^2.0.9",
-                "@smithy/smithy-client": "^2.1.5",
-                "@smithy/types": "^2.3.2",
+                "@smithy/property-provider": "^2.1.1",
+                "@smithy/smithy-client": "^2.3.1",
+                "@smithy/types": "^2.9.1",
                 "bowser": "^2.11.0",
                 "tslib": "^2.5.0"
             }
         },
         "@smithy/util-defaults-mode-node": {
-            "version": "2.0.11",
-            "dev": true,
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.2.0.tgz",
+            "integrity": "sha512-iFJp/N4EtkanFpBUtSrrIbtOIBf69KNuve03ic1afhJ9/korDxdM0c6cCH4Ehj/smI9pDCfVv+bqT3xZjF2WaA==",
             "requires": {
-                "@smithy/config-resolver": "^2.0.9",
-                "@smithy/credential-provider-imds": "^2.0.11",
-                "@smithy/node-config-provider": "^2.0.11",
-                "@smithy/property-provider": "^2.0.9",
-                "@smithy/smithy-client": "^2.1.5",
-                "@smithy/types": "^2.3.2",
+                "@smithy/config-resolver": "^2.1.1",
+                "@smithy/credential-provider-imds": "^2.2.1",
+                "@smithy/node-config-provider": "^2.2.1",
+                "@smithy/property-provider": "^2.1.1",
+                "@smithy/smithy-client": "^2.3.1",
+                "@smithy/types": "^2.9.1",
                 "tslib": "^2.5.0"
             }
         },
         "@smithy/util-hex-encoding": {
-            "version": "2.0.0",
-            "dev": true,
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.1.1.tgz",
+            "integrity": "sha512-3UNdP2pkYUUBGEXzQI9ODTDK+Tcu1BlCyDBaRHwyxhA+8xLP8agEKQq4MGmpjqb4VQAjq9TwlCQX0kP6XDKYLg==",
             "requires": {
                 "tslib": "^2.5.0"
             }
         },
         "@smithy/util-middleware": {
-            "version": "2.0.1",
-            "dev": true,
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.1.1.tgz",
+            "integrity": "sha512-mKNrk8oz5zqkNcbcgAAepeJbmfUW6ogrT2Z2gDbIUzVzNAHKJQTYmH9jcy0jbWb+m7ubrvXKb6uMjkSgAqqsFA==",
             "requires": {
-                "@smithy/types": "^2.3.2",
+                "@smithy/types": "^2.9.1",
                 "tslib": "^2.5.0"
             }
         },
         "@smithy/util-retry": {
-            "version": "2.0.1",
-            "dev": true,
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.1.1.tgz",
+            "integrity": "sha512-Mg+xxWPTeSPrthpC5WAamJ6PW4Kbo01Fm7lWM1jmGRvmrRdsd3192Gz2fBXAMURyXpaNxyZf6Hr/nQ4q70oVEA==",
             "requires": {
-                "@smithy/service-error-classification": "^2.0.1",
-                "@smithy/types": "^2.3.2",
+                "@smithy/service-error-classification": "^2.1.1",
+                "@smithy/types": "^2.9.1",
                 "tslib": "^2.5.0"
             }
         },
         "@smithy/util-stream": {
-            "version": "2.0.11",
-            "dev": true,
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.1.1.tgz",
+            "integrity": "sha512-J7SMIpUYvU4DQN55KmBtvaMc7NM3CZ2iWICdcgaovtLzseVhAqFRYqloT3mh0esrFw+3VEK6nQFteFsTqZSECQ==",
             "requires": {
-                "@smithy/fetch-http-handler": "^2.1.4",
-                "@smithy/node-http-handler": "^2.1.4",
-                "@smithy/types": "^2.3.2",
-                "@smithy/util-base64": "^2.0.0",
-                "@smithy/util-buffer-from": "^2.0.0",
-                "@smithy/util-hex-encoding": "^2.0.0",
-                "@smithy/util-utf8": "^2.0.0",
+                "@smithy/fetch-http-handler": "^2.4.1",
+                "@smithy/node-http-handler": "^2.3.1",
+                "@smithy/types": "^2.9.1",
+                "@smithy/util-base64": "^2.1.1",
+                "@smithy/util-buffer-from": "^2.1.1",
+                "@smithy/util-hex-encoding": "^2.1.1",
+                "@smithy/util-utf8": "^2.1.1",
                 "tslib": "^2.5.0"
             }
         },
         "@smithy/util-uri-escape": {
-            "version": "2.0.0",
-            "dev": true,
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.1.1.tgz",
+            "integrity": "sha512-saVzI1h6iRBUVSqtnlOnc9ssU09ypo7n+shdQ8hBTZno/9rZ3AuRYvoHInV57VF7Qn7B+pFJG7qTzFiHxWlWBw==",
             "requires": {
                 "tslib": "^2.5.0"
             }
         },
         "@smithy/util-utf8": {
-            "version": "2.0.0",
-            "dev": true,
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.1.1.tgz",
+            "integrity": "sha512-BqTpzYEcUMDwAKr7/mVRUtHDhs6ZoXDi9NypMvMfOr/+u1NW7JgqodPDECiiLboEm6bobcPcECxzjtQh865e9A==",
             "requires": {
-                "@smithy/util-buffer-from": "^2.0.0",
+                "@smithy/util-buffer-from": "^2.1.1",
                 "tslib": "^2.5.0"
             }
         },
@@ -18068,7 +18151,8 @@
         },
         "bowser": {
             "version": "2.11.0",
-            "dev": true
+            "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+            "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
         },
         "brace-expansion": {
             "version": "1.1.11",
@@ -19011,7 +19095,8 @@
         },
         "fast-xml-parser": {
             "version": "4.2.5",
-            "dev": true,
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
+            "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
             "requires": {
                 "strnum": "^1.0.5"
             }
@@ -22581,7 +22666,8 @@
         },
         "strnum": {
             "version": "1.0.5",
-            "dev": true
+            "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+            "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
         },
         "supports-color": {
             "version": "5.5.0",
@@ -22741,8 +22827,7 @@
             }
         },
         "tslib": {
-            "version": "2.6.2",
-            "dev": true
+            "version": "2.6.2"
         },
         "tsutils": {
             "version": "3.21.0",

--- a/package.json
+++ b/package.json
@@ -37,12 +37,12 @@
         "test": "jest"
     },
     "dependencies": {
+        "@aws-sdk/client-quicksight": "^3.414.0",
         "@babel/runtime": "^7.20.6",
         "punycode": "^2.1.1",
         "uuid": "^9.0.0"
     },
     "devDependencies": {
-        "@aws-sdk/client-quicksight": "^3.414.0",
         "@babel/cli": "^7.19.3",
         "@babel/core": "^7.20.5",
         "@babel/plugin-transform-runtime": "^7.19.6",


### PR DESCRIPTION
*[Issue #, if available:](https://github.com/awslabs/amazon-quicksight-embedding-sdk/issues/195)*

*Description of changes:*
This PR moves the `@aws-sdk/client-quicksight": "^3.414.0` to dependencies, ensuring that all necessary runtime dependencies are correctly managed and installed with the SDK.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
