### PR TITLE
Remove duplicate 'ja-JP (日本語),'  in available locale options

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,7 +334,6 @@ Available locale options are:
 en-US (English),
 da-DK (Dansk)
 de-DE (Deutsch),
-ja-JP (日本語),
 es-ES (Español),
 fr-FR (Français),
 it-IT (Italiano),


### PR DESCRIPTION
*Issue #, if available:*
fix document.
Remove duplicate 'ja-JP (日本語),'  in available locale options.

*Description of changes:*

In 'available locale options', 'ja-JP (日本語),' was duplicated, so one of the two was removed.

https://github.com/awslabs/amazon-quicksight-embedding-sdk?tab=readme-ov-file#common-properties-of-contentoptions-for-all-embedding-experiences


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
