### PR TITLE
Increased MESSAGE_RESPONSE_TIMEOUT to 20 seconds

### DIFF
--- a/src/experiences/base-experience/frame/experience-frame.ts
+++ b/src/experiences/base-experience/frame/experience-frame.ts
@@ -41,7 +41,7 @@ export abstract class BaseExperienceFrame<
     protected readonly internalExperience: InternalExperience;
     protected readonly onChange: EventListener;
     protected url: string;
-    private readonly MESSAGE_RESPONSE_TIMEOUT = 5000;
+    private readonly MESSAGE_RESPONSE_TIMEOUT = 20000;
 
     public iframe: EmbeddingIFrameElement | null = null;
     public container: HTMLElement;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Increased MESSAGE_RESPONSE_TIMEOUT to 20 seconds to avoid errors when executing setParameters with large data volumes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
