### PR TITLE
fix TS2430: Interface 'EmbeddingIFrameElement' incorrectly extends in…

### DIFF
--- a/src/common/iframe/types.ts
+++ b/src/common/iframe/types.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 export interface EmbeddingIFrameElement extends HTMLIFrameElement {
-    loading: string;
 }
 
 export type IframeOptions = {


### PR DESCRIPTION
TS2430: Interface 'EmbeddingIFrameElement' incorrectly extends in iterface 'HTMLIFrameElement'

*Issue #246

*Description of changes:*
Remove loading field from EmbeddingIFrameElement class because of typescript error.
The cause is from dupplicate loading field which already exist in extend class: HTMLIFrameElement. So I remove this field from EmbeddingIFrameElement class

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
